### PR TITLE
Add groupWhile function

### DIFF
--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -344,7 +344,44 @@ getSuite =
             ]
 
 
+groupSuite =
+    let
+        groupWhile f xs =
+            NE.groupWhile f xs
+                |> NE.toList
+                |> List.map NE.toList
+
+        xs1 =
+            NE.Nonempty ( 0, 'a' ) [ ( 0, 'b' ), ( 1, 'c' ), ( 1, 'd' ) ]
+
+        xs2 =
+            NE.Nonempty 1 [ 2, 3, 2, 4, 1, 3, 2, 1 ]
+    in
+        describe "group"
+            [ test "" <|
+                \_ ->
+                    groupWhile (\x y -> Tuple.first x == Tuple.first y) xs1
+                        |> Expect.equal [ [ ( 0, 'a' ), ( 0, 'b' ) ], [ ( 1, 'c' ), ( 1, 'd' ) ] ]
+            , test "" <|
+                \_ ->
+                    groupWhile (<) xs2
+                        |> Expect.equal [ [ 1 ], [ 2 ], [ 3, 2 ], [ 4, 1 ], [ 3, 2, 1 ] ]
+            , test "A single element should become nested." <|
+                \_ ->
+                    groupWhile (==) (NE.Nonempty 1 [])
+                        |> Expect.equal [ [ 1 ] ]
+            , test "Two adjacent like elements should be grouped together." <|
+                \_ ->
+                    groupWhile (==) (NE.Nonempty 1 [ 1 ])
+                        |> Expect.equal [ [ 1, 1 ] ]
+            , test "Two non-adjacent like elements should not be grouped together." <|
+                \_ ->
+                    groupWhile (==) (NE.Nonempty 1 [ 1, 2, 3, 1 ])
+                        |> Expect.equal [ [ 1, 1 ], [ 2 ], [ 3 ], [ 1 ] ]
+            ]
+
+
 all : Test
 all =
     describe "All Nonempty List tests"
-        [ testSuite, getSuite, dedupeSuite, uniqSuite ]
+        [ testSuite, getSuite, dedupeSuite, uniqSuite, groupSuite ]

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -358,11 +358,11 @@ groupSuite =
             NE.Nonempty 1 [ 2, 3, 2, 4, 1, 3, 2, 1 ]
     in
         describe "group"
-            [ test "" <|
+            [ test "The tuples should be grouped by their first elements." <|
                 \_ ->
                     groupWhile (\x y -> Tuple.first x == Tuple.first y) xs1
                         |> Expect.equal [ [ ( 0, 'a' ), ( 0, 'b' ) ], [ ( 1, 'c' ), ( 1, 'd' ) ] ]
-            , test "" <|
+            , test "A demonstration of a non-equivalent relations predicate; probably not a useful thing to do." <|
                 \_ ->
                     groupWhile (<) xs2
                         |> Expect.equal [ [ 1 ], [ 2 ], [ 3, 2 ], [ 4, 1 ], [ 3, 2, 1 ] ]


### PR DESCRIPTION
Here's a pull request for *issue* #3.

It adds a *groupWhile* function which is similar (in intent) to the function of the same name in the community List.Extra package.

There's one difference I'm aware of: the *non-intuitive behavior* that occurs when using non-equivalent relations is not the same.