### PR TITLE
Add fromListWithDefault, with tests

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "mgold/elm-nonempty-list",
     "summary": "head and tail without the Maybe",
     "license": "BSD-3-Clause",
-    "version": "4.0.0",
+    "version": "4.1.0",
     "exposed-modules": ["List.Nonempty"],
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {

--- a/src/List/Nonempty.elm
+++ b/src/List/Nonempty.elm
@@ -1,4 +1,17 @@
-module List.Nonempty exposing (Nonempty(..), all, andMap, any, append, concat, concatMap, cons, dedup, dropTail, filter, foldl, foldl1, fromElement, fromList, get, head, indexedMap, isSingleton, length, map, map2, member, pop, replaceHead, replaceTail, reverse, sample, sort, sortBy, sortWith, tail, toList, uniq, unzip, zip)
+module List.Nonempty exposing
+    ( Nonempty(..)
+    , fromElement, fromList, fromListWithDefault
+    , head, tail, toList, get, sample
+    , isSingleton, length, member, all, any
+    , cons, append, pop, reverse, concat
+    , replaceHead, replaceTail, dropTail
+    , map, indexedMap, map2, andMap, concatMap
+    , filter
+    , foldl, foldl1
+    , zip, unzip
+    , sort, sortBy, sortWith
+    , dedup, uniq
+    )
 
 {-| A list that cannot be empty. The head and tail can be accessed without Maybes. Most other list functions are
 available.
@@ -11,7 +24,7 @@ available.
 
 # Create
 
-@docs fromElement, fromList
+@docs fromElement, fromList, fromListWithDefault
 
 
 # Access
@@ -100,6 +113,19 @@ fromList ys =
             Nothing
 
 
+{-| Create a nonempty list from an ordinary list, using the provided default
+value to ensure non-emptiness.
+-}
+fromListWithDefault : List a -> a -> Nonempty a
+fromListWithDefault ys default =
+    case ys of
+        [] ->
+            Nonempty default []
+
+        x :: xs ->
+            Nonempty x xs
+
+
 {-| Return the head of the list.
 -}
 head : Nonempty a -> a
@@ -177,7 +203,7 @@ append (Nonempty x xs) (Nonempty y ys) =
 {-| Pop and discard the head, or do nothing for a singleton list. Useful if you
 want to exhaust a list but hang on to the last item indefinitely.
 
-    pop (Nonempty 3 [2,1]) --> Nonempty 2 [1]
+    pop (Nonempty 3 [ 2, 1 ]) --> Nonempty 2 [1]
 
     pop (Nonempty 1 []) --> Nonempty 1 []
 
@@ -261,7 +287,8 @@ map2 f (Nonempty x xs) (Nonempty y ys) =
 {-| Map over an arbitrary number of nonempty lists.
 
     map2 (,) xs ys == map (,) xs |> andMap ys
-    head (map (,,) xs |> andMap ys |> andMap zs) == (head xs, head ys, head zs)
+
+    head (map (,,) xs |> andMap ys |> andMap zs) == ( head xs, head ys, head zs )
 
 -}
 andMap : Nonempty a -> Nonempty (a -> b) -> Nonempty b
@@ -386,7 +413,7 @@ sortWith f (Nonempty x xs) =
 
 {-| Remove _adjacent_ duplicate elements from the nonempty list.
 
-    dedup (Nonempty 1 [2, 2, 1]) --> Nonempty 1 [2, 1]
+    dedup (Nonempty 1 [ 2, 2, 1 ]) --> Nonempty 1 [2, 1]
 
 -}
 dedup : Nonempty a -> Nonempty a
@@ -410,7 +437,7 @@ dedup (Nonempty x xs) =
 
 {-| Remove _all_ duplicate elements from the nonempty list, with the remaining elements ordered by first occurrence.
 
-    uniq (Nonempty 1 [2, 2, 1]) --> Nonempty 1 [2]
+    uniq (Nonempty 1 [ 2, 2, 1 ]) --> Nonempty 1 [2]
 
 -}
 uniq : Nonempty a -> Nonempty a
@@ -434,7 +461,7 @@ uniq (Nonempty x xs) =
 
 {-| Reduce a nonempty list from the left with a base case.
 
-    foldl (++) "" (Nonempty "a" ["b", "c"]) --> "cba"
+    foldl (++) "" (Nonempty "a" [ "b", "c" ]) --> "cba"
 
 -}
 foldl : (a -> b -> b) -> b -> Nonempty a -> b

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -1,4 +1,4 @@
-module Tests exposing (..)
+module Tests exposing (dedupeSuite, f, fromListWithDefaultSuite, getSuite, isEven, nonemptylist, testSuite, uncurry, uniqSuite)
 
 import Expect
 import Fuzz exposing (char, int, list, string, tuple, tuple3)
@@ -308,4 +308,25 @@ getSuite =
         , test "1" <| \_ -> NE.get 1 xs |> Expect.equal 11
         , test "2" <| \_ -> NE.get 2 xs |> Expect.equal 12
         , test "3" <| \_ -> NE.get 3 xs |> Expect.equal 10
+        ]
+
+
+fromListWithDefaultSuite =
+    describe "fromListWithDefault"
+        [ fuzz int "Empty list returns default" <|
+            \default ->
+                NE.fromListWithDefault [] default
+                    |> NE.toList
+                    |> Expect.equal [ default ]
+
+        -- 👇 list fuzzer doesn't work here because it generates `[]`
+        , test "Non-empthy list comes through unaltered" <|
+            \_ ->
+                let
+                    list =
+                        [ 3.14159265359, 2.7182818284, 42 ]
+                in
+                NE.fromListWithDefault list 0
+                    |> NE.toList
+                    |> Expect.equal list
         ]


### PR DESCRIPTION
Unlike `fromList`, `fromListWithDefault` doesn't have a `Maybe` in the type signature. 🎊

Compare:

```
fromList : List a -> Maybe (Nonempty a)
```
```
fromListWithDefault : List a -> a -> Nonempty a
```

I think this fits better with your original goals. If I may be so bold, it might be worth doing a major release with the following changes:

- Delete `fromList`
- Rename `fromListWithDefault` 👉 `fromList`

If, after giving that some thought, you'd like me to do just that in a pull request to save yourself 10 minutes, say the word. Either way, thanks for this nice simple utility class!