### PR TITLE
Add fromListWithDefault (w/ tests & travis fix)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js:
   - "7"
 install:
   - npm install -g elm
-  - npm install -g elm-test@beta
+  - npm install -g elm-test
   - npm install -g elm-verify-examples
 script:
   - elm make

--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "mgold/elm-nonempty-list",
     "summary": "head and tail without the Maybe",
     "license": "BSD-3-Clause",
-    "version": "4.0.0",
+    "version": "4.1.0",
     "exposed-modules": ["List.Nonempty"],
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {

--- a/src/List/Nonempty.elm
+++ b/src/List/Nonempty.elm
@@ -1,4 +1,4 @@
-module List.Nonempty exposing (Nonempty(..), all, andMap, any, append, concat, concatMap, cons, dedup, dropTail, filter, foldl, foldl1, fromElement, fromList, get, head, indexedMap, isSingleton, length, map, map2, member, pop, replaceHead, replaceTail, reverse, sample, sort, sortBy, sortWith, tail, toList, uniq, unzip, zip)
+module List.Nonempty exposing (Nonempty(..), all, andMap, any, append, concat, concatMap, cons, dedup, dropTail, filter, foldl, foldl1, fromElement, fromList, fromListWithDefault, get, head, indexedMap, isSingleton, length, map, map2, member, pop, replaceHead, replaceTail, reverse, sample, sort, sortBy, sortWith, tail, toList, uniq, unzip, zip)
 
 {-| A list that cannot be empty. The head and tail can be accessed without Maybes. Most other list functions are
 available.
@@ -11,7 +11,7 @@ available.
 
 # Create
 
-@docs fromElement, fromList
+@docs fromElement, fromList, fromListWithDefault
 
 
 # Access
@@ -98,6 +98,19 @@ fromList ys =
 
         _ ->
             Nothing
+
+
+{-| Create a nonempty list from an ordinary list, using the provided default
+value to ensure non-emptiness.
+-}
+fromListWithDefault : List a -> a -> Nonempty a
+fromListWithDefault ys default =
+    case ys of
+        [] ->
+            Nonempty default []
+
+        x :: xs ->
+            Nonempty x xs
 
 
 {-| Return the head of the list.

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -309,3 +309,24 @@ getSuite =
         , test "2" <| \_ -> NE.get 2 xs |> Expect.equal 12
         , test "3" <| \_ -> NE.get 3 xs |> Expect.equal 10
         ]
+
+
+fromListWithDefaultSuite =
+    describe "fromListWithDefault"
+        [ fuzz int "Empty list returns default" <|
+            \default ->
+                NE.fromListWithDefault [] default
+                    |> NE.toList
+                    |> Expect.equal [ default ]
+
+        -- 👇 list fuzzer doesn't work here because it generates `[]`
+        , test "Non-empthy list comes through unaltered" <|
+            \_ ->
+                let
+                    list =
+                        [ 3.14159265359, 2.7182818284, 42 ]
+                in
+                NE.fromListWithDefault list 0
+                    |> NE.toList
+                    |> Expect.equal list
+        ]


### PR DESCRIPTION
Unlike `fromList`, `fromListWithDefault` doesn't have a `Maybe` in the type signature. 🎊

Compare:

```
fromList : List a -> Maybe (Nonempty a)
```
```
fromListWithDefault : List a -> a -> Nonempty a
```

I think this fits better with your original goals. If I may be so bold, it might be worth doing a major release with the following changes:

- Delete `fromList`
- Rename `fromListWithDefault` 👉 `fromList`

If, after giving that some thought, you'd like me to do just that in a pull request to save yourself 10 minutes, say the word. Either way, thanks for this nice simple utility class!