### PR TITLE
Remove README references to infix cons operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ one : Nonempty Int
 one = fromElement 2
 
 two : Nonempty Int
-two = 4 ::: one
+two = cons 4 one
 
 toList two --> [4, 2]
 
@@ -30,8 +30,8 @@ member 4 two --> True
 foldl1 (+) two --> 6
 ```
 
-For actual usage, I recommend `import List.Nonempty as NE exposing (Nonempty,
-(:::))` to import the type and infix cons.
+For actual usage, I recommend `import List.Nonempty as NE exposing (Nonempty)`
+to just import the type.
 
 ## Testing
 

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -1,6 +1,7 @@
 {
   "root": "../src",
   "tests": [
-    "List.Nonempty"
+    "List.Nonempty",
+    "./README.md"
   ]
 }


### PR DESCRIPTION
This no longer exists as of 4.0.0. Thanks :slightly_smiling_face: 