### PR TITLE
Added `consumeWith`.

### DIFF
--- a/src/List/Nonempty.elm
+++ b/src/List/Nonempty.elm
@@ -11,6 +11,7 @@ module List.Nonempty exposing
     , zip, unzip
     , sort, sortBy, sortWith
     , dedup, uniq
+    , consumeWith
     , fromElement
     )
 
@@ -82,6 +83,11 @@ To fold or scan from the right, reverse the list first.
 The nonempty list's elements must support equality (e.g. not functions). Otherwise you will get a runtime error.
 
 @docs dedup, uniq
+
+
+# Consumption
+
+@docs consumeWith
 
 
 # Deprecated
@@ -548,3 +554,27 @@ unzip (Nonempty ( x, y ) rest) =
             List.unzip rest
     in
     ( Nonempty x xs, Nonempty y ys )
+
+
+{-| Use a non-empty list as arguments for functions with the type signature `a -> List a -> Something`, such as `Random.weighted`. This is designed to be used in a pipe style.
+
+    import Random
+
+    type PrizeMoneyInDollars
+        = PrizeMoneyInDollars Int
+
+    lotteryGenerator : Random.Generator Int
+    lotteryGenerator =
+        Nonempty 1 [ 2, 3, 4, 5 ]
+            |> Nonempty.map
+                (\i ->
+                    ( toFloat (10 ^ i)
+                    , PrizeMoneyInDollars (10 ^ (6 - i))
+                    )
+                )
+            |> Nonempty.consumeWith Random.weighted
+
+-}
+consumeWith : (a -> List a -> b) -> Nonempty a -> b
+consumeWith func (Nonempty x xs) =
+    func x xs

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -250,6 +250,11 @@ testSuite =
                 NE.take n (NE.Nonempty x xs)
                     |> NE.toList
                     |> Expect.equalLists expectedResult
+        , fuzz2 int (list int) "consumeWith works." <|
+            \n ns ->
+                NE.Nonempty n ns
+                    |> NE.consumeWith NE.Nonempty
+                    |> Expect.equal (NE.Nonempty n ns)
         ]
 
 


### PR DESCRIPTION
Thank you for creating and maintaining this package with such a nice API. I would love to use it!

I would like to suggest adding a combinator for applying functions to `List.Nonempty`, with the type signature `a -> List a -> Something`.

This kind of signature is commonly found in Elm when a function requires a non-empty collection of a data type, so the combinator fits well with the `Nonempty` type (please refer to the example code where `Random.weighted` is applied to `Nonempty`).

I named this combinator `consumeWith`, as it conveys the idea of converting `Nonempty` to another data type, often indicating the end of the role for that `Nonempty` data. If you prefer a different name, feel free to rename it.

